### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/gejjech/Bvv/security/code-scanning/1](https://github.com/gejjech/Bvv/security/code-scanning/1)

To fix the problem, you should set the `permissions` key in the workflow YAML file to restrict the permissions granted to the GITHUB_TOKEN. The most secure default for most CI workflows is `contents: read`, which allows the workflow to read repository contents but not make any changes. This should be added at the root level of the workflow (directly under `name: CI`), so the restriction applies to every job in the workflow unless specifically overridden. No changes to the jobs or steps are necessary. You only need to add the following block:

```yaml
permissions:
  contents: read
```

Add this right after the `name: CI` line and before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
